### PR TITLE
Simon

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
+++ b/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
@@ -273,9 +273,12 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
         } else if (id == R.id.nav_edit_profile) {
             //FIXME Implement this
             // Navigate to EditProfileActivity
-//            Intent intent = new Intent(EntrantHomeActivity.this, EditProfileActivity.class);
-//            startActivity(intent);
-            Toast.makeText(this, "Edit Profile feature not implemented yet.", Toast.LENGTH_SHORT).show();
+            Intent intent = new Intent(EntrantHomeActivity.this, UserInfoActivity.class);
+            intent.putExtra("USER_TYPE", "Entrant"); // or "Organizer"
+            intent.putExtra("MODE", "EDIT");
+            startActivity(intent);
+
+//            Toast.makeText(this, "Edit Profile feature not implemented yet.", Toast.LENGTH_SHORT).show();
         }
 
         drawerLayout.closeDrawer(GravityCompat.START);

--- a/app/src/main/java/com/example/potato1_events/LandingActivity.java
+++ b/app/src/main/java/com/example/potato1_events/LandingActivity.java
@@ -66,6 +66,7 @@ public class LandingActivity extends AppCompatActivity {
                         // User does not exist, navigate to UserInfoActivity
                         Intent intent = new Intent(LandingActivity.this, UserInfoActivity.class);
                         intent.putExtra("USER_TYPE", userType);
+                        intent.putExtra("MODE", "CREATE");
                         startActivity(intent);
                     }
                 })

--- a/app/src/main/java/com/example/potato1_events/User.java
+++ b/app/src/main/java/com/example/potato1_events/User.java
@@ -1,20 +1,24 @@
 package com.example.potato1_events;
 
 import com.google.firebase.firestore.Exclude;
+import com.google.firebase.firestore.IgnoreExtraProperties;
 
 /**
  * Represents a user within the Potato1 Events application.
  * This class includes all necessary information for entrants, organizers, and administrators.
  */
+@IgnoreExtraProperties // Ensures Firestore ignores any extra fields not mapped in this class
 public class User {
     private String userId; // Firebase Authentication UID
     private String role; // Entrant, Organizer, Admin
     private String name;
     private String email;
     private String phoneNumber;
-    private String profilePictureUrl;
+    private String imagePath; // Firebase Storage path for profile picture
     private boolean notificationsEnabled; // For opting in/out of notifications
     private long createdAt; // Timestamp of account creation
+    private long updatedAt; // Timestamp of last update
+    private boolean isActive; // Indicates if the user account is active
 
     /**
      * Default constructor required for Firestore serialization.
@@ -25,23 +29,23 @@ public class User {
     /**
      * Parameterized constructor to create a User object.
      *
-     * @param userId             The unique identifier (UID) from Firebase Authentication.
-     * @param role               The role of the user (Entrant, Organizer, Admin).
-     * @param name               The user's full name.
-     * @param email              The user's email address.
-     * @param phoneNumber        The user's phone number.
-     * @param profilePictureUrl  The URL to the user's profile picture.
+     * @param userId               The unique identifier (UID) from Firebase Authentication.
+     * @param role                 The role of the user (Entrant, Organizer, Admin).
+     * @param name                 The user's full name.
+     * @param email                The user's email address.
+     * @param phoneNumber          The user's phone number.
+     * @param imagePath            The Firebase Storage path to the user's profile picture.
      * @param notificationsEnabled Whether the user has opted in for notifications.
-     * @param createdAt          Timestamp of when the user was created.
+     * @param createdAt            Timestamp of when the user was created.
      */
     public User(String userId, String role, String name, String email, String phoneNumber,
-                String profilePictureUrl, boolean notificationsEnabled, long createdAt) {
+                String imagePath, boolean notificationsEnabled, long createdAt) {
         this.userId = userId;
         this.role = role;
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.profilePictureUrl = profilePictureUrl;
+        this.imagePath = imagePath;
         this.notificationsEnabled = notificationsEnabled;
         this.createdAt = createdAt;
     }
@@ -139,21 +143,21 @@ public class User {
     }
 
     /**
-     * Gets the URL of the user's profile picture.
+     * Gets the Firebase Storage path of the user's profile picture.
      *
-     * @return The profile picture URL.
+     * @return The profile picture storage path.
      */
-    public String getProfilePictureUrl() {
-        return profilePictureUrl;
+    public String getImagePath() {
+        return imagePath;
     }
 
     /**
-     * Sets the URL of the user's profile picture.
+     * Sets the Firebase Storage path of the user's profile picture.
      *
-     * @param profilePictureUrl The profile picture URL.
+     * @param imagePath The profile picture storage path.
      */
-    public void setProfilePictureUrl(String profilePictureUrl) {
-        this.profilePictureUrl = profilePictureUrl;
+    public void setImagePath(String imagePath) {
+        this.imagePath = imagePath;
     }
 
     /**

--- a/app/src/main/java/com/example/potato1_events/UserInfoActivity.java
+++ b/app/src/main/java/com/example/potato1_events/UserInfoActivity.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
@@ -23,29 +24,30 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.storage.FirebaseStorage;
-import com.google.firebase.storage.StorageReference;
-import com.google.firebase.storage.UploadTask;
-
 // Import for image loading
 import com.squareup.picasso.Picasso;
 
 // Import for CircleImageView
 import de.hdodenhof.circleimageview.CircleImageView;
 
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
 import java.io.ByteArrayOutputStream;
 import java.util.UUID;
 
 /**
  * Activity responsible for handling user information, including profile picture selection,
- * uploading images to Firebase Storage, generating default avatars, and saving user data to Firestore.
+ * uploading images to Firebase Storage, generating default avatars, and saving/updating user data to Firestore.
  */
 public class UserInfoActivity extends AppCompatActivity {
 
     private static final String TAG = "UserInfoActivity";
+
+    // Modes
+    private static final String MODE_CREATE = "CREATE";
+    private static final String MODE_EDIT = "EDIT";
 
     private String userType;
     private String deviceId;
@@ -53,11 +55,15 @@ public class UserInfoActivity extends AppCompatActivity {
     private FirebaseStorage storage;
 
     private CircleImageView profileImageView;
-    private Button uploadPictureButton;
+    private Button uploadRemovePictureButton;
     private EditText nameEditText, emailEditText, phoneEditText;
     private Button saveButton;
 
     private Uri selectedImageUri = null; // To store the selected image URI
+    private boolean isProfilePictureRemoved = false; // Flag to indicate if the user removed the picture
+
+    // Variables to hold existing image paths
+    private String existingImagePath = null; // The current image path in Firestore
 
     // ActivityResultLauncher for selecting image
     private ActivityResultLauncher<String> selectImageLauncher;
@@ -65,14 +71,24 @@ public class UserInfoActivity extends AppCompatActivity {
     // ActivityResultLauncher for requesting permissions
     private ActivityResultLauncher<String> requestPermissionLauncher;
 
+    // Current mode: CREATE or EDIT
+    private String mode;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_user_info);
 
-        // Get user type from intent
+        // Get user type and mode from intent
         userType = getIntent().getStringExtra("USER_TYPE");
+        mode = getIntent().getStringExtra("MODE"); // Expected to be "CREATE" or "EDIT"
+
+        if (userType == null || (!mode.equals(MODE_CREATE) && !mode.equals(MODE_EDIT))) {
+            Toast.makeText(this, "Invalid mode or user type.", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
 
         // Get device ID
         deviceId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
@@ -83,7 +99,7 @@ public class UserInfoActivity extends AppCompatActivity {
 
         // Initialize views
         profileImageView = findViewById(R.id.profileImageView);
-        uploadPictureButton = findViewById(R.id.uploadPictureButton);
+        uploadRemovePictureButton = findViewById(R.id.uploadPictureButton);
         nameEditText = findViewById(R.id.nameEditText);
         emailEditText = findViewById(R.id.emailEditText);
         phoneEditText = findViewById(R.id.phoneEditText);
@@ -95,8 +111,11 @@ public class UserInfoActivity extends AppCompatActivity {
                 uri -> {
                     if (uri != null) {
                         selectedImageUri = uri;
+                        isProfilePictureRemoved = false; // Reset removal flag
                         // Display the selected image in ImageView
                         Picasso.get().load(uri).into(profileImageView);
+                        // Change button text to "Remove Picture"
+                        uploadRemovePictureButton.setText("Remove Picture");
                     }
                 }
         );
@@ -114,17 +133,33 @@ public class UserInfoActivity extends AppCompatActivity {
         );
 
         // Set up listeners
-        uploadPictureButton.setOnClickListener(v -> {
-            // Check and request permissions if necessary
-            if (ContextCompat.checkSelfPermission(this, getReadPermission()) == PackageManager.PERMISSION_GRANTED) {
-                openImageSelector();
-            } else {
-                // Request permission
-                requestPermissionLauncher.launch(getReadPermission());
+        uploadRemovePictureButton.setOnClickListener(v -> {
+            String buttonText = uploadRemovePictureButton.getText().toString();
+            if (buttonText.equals("Upload Picture")) {
+                // Upload Picture functionality
+                // Check and request permissions if necessary
+                if (ContextCompat.checkSelfPermission(this, getReadPermission()) == PackageManager.PERMISSION_GRANTED) {
+                    openImageSelector();
+                } else {
+                    // Request permission
+                    requestPermissionLauncher.launch(getReadPermission());
+                }
+            } else if (buttonText.equals("Remove Picture")) {
+                // Remove Picture functionality
+                removeProfilePicture();
             }
         });
 
         saveButton.setOnClickListener(v -> saveUserInfo());
+
+        // If in EDIT mode, load existing user data
+        if (mode.equals(MODE_EDIT)) {
+            loadUserData();
+        } else {
+            // In CREATE mode, set default UI state
+            generateAndSetDefaultAvatar("");
+            uploadRemovePictureButton.setText("Upload Picture");
+        }
     }
 
     /**
@@ -149,8 +184,56 @@ public class UserInfoActivity extends AppCompatActivity {
     }
 
     /**
-     * Handles the process of saving user information, including uploading a selected image
-     * or generating a default avatar if no image is selected.
+     * Loads the existing user data from Firestore and pre-fills the input fields.
+     */
+    private void loadUserData() {
+        saveButton.setEnabled(false); // Disable save button while loading
+        firestore.collection(userType + "s").document(deviceId).get()
+                .addOnSuccessListener(documentSnapshot -> {
+                    if (documentSnapshot.exists()) {
+                        User user = documentSnapshot.toObject(User.class);
+                        if (user != null) {
+                            nameEditText.setText(user.getName());
+                            emailEditText.setText(user.getEmail());
+                            phoneEditText.setText(user.getPhoneNumber());
+
+                            existingImagePath = user.getImagePath(); // Store the existing image path
+
+                            if (existingImagePath != null) {
+                                StorageReference imageRef = storage.getReference().child(existingImagePath);
+                                imageRef.getDownloadUrl()
+                                        .addOnSuccessListener(uri -> {
+                                            Picasso.get().load(uri).into(profileImageView);
+                                            uploadRemovePictureButton.setText("Remove Picture");
+                                        })
+                                        .addOnFailureListener(e -> {
+                                            // If failed to load, set default avatar and button text
+                                            generateAndSetDefaultAvatar(user.getName());
+                                            uploadRemovePictureButton.setText("Upload Picture");
+                                            Log.e(TAG, "Failed to load profile image: " + e.getMessage());
+                                        });
+                            } else {
+                                // No imagePath, generate default avatar
+                                generateAndSetDefaultAvatar(user.getName());
+                                uploadRemovePictureButton.setText("Upload Picture");
+                            }
+                        }
+                    } else {
+                        Toast.makeText(UserInfoActivity.this, "User data not found.", Toast.LENGTH_SHORT).show();
+                        finish();
+                    }
+                    saveButton.setEnabled(true);
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(UserInfoActivity.this, "Error loading user data: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Error loading user data", e);
+                    saveButton.setEnabled(true);
+                });
+    }
+
+    /**
+     * Handles the process of saving or updating user information, including uploading a selected image
+     * or handling image removal, and updating Firestore accordingly.
      */
     private void saveUserInfo() {
         String name = nameEditText.getText().toString().trim();
@@ -165,17 +248,46 @@ public class UserInfoActivity extends AppCompatActivity {
         // Disable the save button to prevent multiple clicks
         saveButton.setEnabled(false);
 
-        if (selectedImageUri != null) {
-            // User has selected an image, upload it to Firebase Storage
+        if (isProfilePictureRemoved) {
+            // Handle profile picture removal
+            if (existingImagePath != null) {
+                // Delete existing image from Firebase Storage
+                StorageReference imageRef = storage.getReference().child(existingImagePath);
+                imageRef.delete()
+                        .addOnSuccessListener(aVoid -> {
+                            Log.d(TAG, "Profile picture deleted successfully.");
+                            // Generate and upload new default avatar
+                            generateAndUploadDefaultAvatar(name, email, phoneNumber);
+                        })
+                        .addOnFailureListener(e -> {
+                            Toast.makeText(UserInfoActivity.this, "Failed to delete profile picture: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                            Log.e(TAG, "Failed to delete profile picture", e);
+                            saveButton.setEnabled(true);
+                        });
+            } else {
+                // No existing image to delete, generate and upload default avatar
+                generateAndUploadDefaultAvatar(name, email, phoneNumber);
+            }
+        }
+        else if (selectedImageUri != null) {
+            // Handle new image selected
             uploadImageToFirebase(name, email, phoneNumber);
-        } else {
-            // No image selected, generate a deterministic avatar
-            generateDefaultAvatarAndSaveUser(name, email, phoneNumber);
+        }
+        else {
+            // No changes to profile picture
+            if (mode.equals(MODE_CREATE)) {
+                // In CREATE mode, generate and upload default avatar
+                generateAndUploadDefaultAvatar(name, email, phoneNumber);
+            }
+            else {
+                // In EDIT mode, keep existing image (if any)
+                updateUserInFirestore(name, email, phoneNumber, existingImagePath);
+            }
         }
     }
 
     /**
-     * Uploads the selected image to Firebase Storage and retrieves its storage path.
+     * Uploads the selected image to Firebase Storage and updates Firestore.
      *
      * @param name        The user's name.
      * @param email       The user's email address.
@@ -190,25 +302,70 @@ public class UserInfoActivity extends AppCompatActivity {
         // Upload the image
         storageRef.putFile(selectedImageUri)
                 .addOnSuccessListener(taskSnapshot -> {
-                    // Instead of getting the download URL, use the storage path
+                    // Get the storage path
                     String imagePath = storageRef.getPath();
-                    saveUserToFirestore(name, email, phoneNumber, imagePath);
+                    // Delete existing image if it exists
+                    if (existingImagePath != null) {
+                        StorageReference existingImageRef = storage.getReference().child(existingImagePath);
+                        existingImageRef.delete()
+                                .addOnSuccessListener(aVoid -> {
+                                    Log.d(TAG, "Existing image deleted successfully.");
+                                    // Update Firestore with new image path
+                                    updateUserInFirestore(name, email, phoneNumber, imagePath);
+                                })
+                                .addOnFailureListener(e -> {
+                                    Toast.makeText(UserInfoActivity.this, "Failed to delete existing image: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                                    Log.e(TAG, "Failed to delete existing image", e);
+                                    saveButton.setEnabled(true);
+                                });
+                    } else {
+                        // No existing image, update Firestore with new image path
+                        updateUserInFirestore(name, email, phoneNumber, imagePath);
+                    }
                 })
                 .addOnFailureListener(e -> {
                     Toast.makeText(UserInfoActivity.this, "Image upload failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Image upload failed", e);
                     saveButton.setEnabled(true);
                 });
     }
 
     /**
-     * Generates a default avatar based on the user's name, uploads it to Firebase Storage,
-     * and saves the user information to Firestore.
+     * Updates the user's information in Firestore.
+     *
+     * @param name        The user's name.
+     * @param email       The user's email address.
+     * @param phoneNumber The user's phone number.
+     * @param imagePath   The image path to save (can be null).
+     */
+    private void updateUserInFirestore(String name, String email, String phoneNumber, String imagePath) {
+        User updatedUser = new User(); // Assuming you have a default constructor
+        updatedUser.setName(name);
+        updatedUser.setEmail(email);
+        updatedUser.setPhoneNumber(phoneNumber);
+        updatedUser.setImagePath(imagePath);
+
+        // Update Firestore document
+        firestore.collection(userType + "s").document(deviceId).set(updatedUser)
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(UserInfoActivity.this, "Profile updated successfully", Toast.LENGTH_SHORT).show();
+                    navigateToHomePage();
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(UserInfoActivity.this, "Error updating profile: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Error updating profile", e);
+                    saveButton.setEnabled(true);
+                });
+    }
+
+    /**
+     * Generates a default avatar, uploads it to Firebase Storage, and updates Firestore.
      *
      * @param name        The user's name.
      * @param email       The user's email address.
      * @param phoneNumber The user's phone number.
      */
-    private void generateDefaultAvatarAndSaveUser(String name, String email, String phoneNumber) {
+    private void generateAndUploadDefaultAvatar(String name, String email, String phoneNumber) {
         // Generate initials from name
         String initials = getInitials(name);
 
@@ -227,52 +384,41 @@ public class UserInfoActivity extends AppCompatActivity {
         // Upload the bitmap
         storageRef.putBytes(data)
                 .addOnSuccessListener(taskSnapshot -> {
-                    // Instead of getting the download URL, use the storage path
+                    // Get the storage path
                     String avatarPath = storageRef.getPath();
-                    // Save user info with avatar path
-                    saveUserToFirestore(name, email, phoneNumber, avatarPath);
+                    // Update Firestore with new default avatar path
+                    updateUserInFirestore(name, email, phoneNumber, avatarPath);
                 })
                 .addOnFailureListener(e -> {
                     Toast.makeText(UserInfoActivity.this, "Default avatar upload failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                    saveUserToFirestore(name, email, phoneNumber, null); // Save without avatar path
+                    Log.e(TAG, "Default avatar upload failed", e);
+                    saveButton.setEnabled(true);
                 });
-
-        // Return a placeholder or null since the actual path will be set asynchronously
-        // No return statement needed as method is void
     }
 
     /**
-     * Saves the user's information to Firestore, including the profile picture storage path.
-     *
-     * @param name        The user's name.
-     * @param email       The user's email address.
-     * @param phoneNumber The user's phone number.
-     * @param imagePath   The storage path of the profile picture.
+     * Removes the profile picture by updating the UI and setting a flag.
+     * The actual deletion will occur when the user clicks "Save".
      */
-    private void saveUserToFirestore(String name, String email, String phoneNumber, String imagePath) {
-        String userId = UUID.randomUUID().toString();
-        // Create user object
-        User user = new User(
-                userId,
-                userType,
-                name,
-                email,
-                phoneNumber,
-                imagePath, // holds the storage path in firebase storage
-                true, // Default to notifications enabled
-                System.currentTimeMillis() // Current timestamp
-        );
+    private void removeProfilePicture() {
+        String name = nameEditText.getText().toString().trim();
+        // Set ImageView to default avatar
+        generateAndSetDefaultAvatar(name);
+        isProfilePictureRemoved = true;
+        selectedImageUri = null; // Reset selected image
+        // Change button text back to "Upload Picture"
+        uploadRemovePictureButton.setText("Upload Picture");
+    }
 
-        // Save to Firestore
-        firestore.collection(userType + "s").document(deviceId).set(user)
-                .addOnSuccessListener(aVoid -> {
-                    Toast.makeText(UserInfoActivity.this, "User information saved", Toast.LENGTH_SHORT).show();
-                    navigateToHomePage();
-                })
-                .addOnFailureListener(e -> {
-                    Toast.makeText(UserInfoActivity.this, "Error saving user information: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                    saveButton.setEnabled(true);
-                });
+    /**
+     * Generates and sets a default avatar locally without uploading to Firebase Storage.
+     *
+     * @param name The user's name.
+     */
+    private void generateAndSetDefaultAvatar(String name) {
+        String initials = getInitials(name);
+        Bitmap bitmap = createAvatarBitmap(initials);
+        profileImageView.setImageBitmap(bitmap);
     }
 
     /**

--- a/app/src/test/java/com/example/potato1_events/Users_OpsTest.java
+++ b/app/src/test/java/com/example/potato1_events/Users_OpsTest.java
@@ -43,7 +43,16 @@ public class Users_OpsTest {
         // Mock the behavior of the set() method returning a Task
         when(mockDocumentReference.set(any(User.class))).thenReturn(mockTask);
 
-        User user = new User("Xavier", "x@gmail.com", "1234", "profile");
+        User user = new User(
+                "1234",
+                "Entrant",
+                "Xavier",
+                "x@gmail.com",
+                "1234",
+                "profile", // holds the storage path in firebase storage
+                true, // Default to notifications enabled
+                System.currentTimeMillis() // Current timestamp
+        );
         // Call the method under test
         Task<Void> result = mockFirestore.collection("Entrants").document("testID").set(user);
         // Verify that Firestore's set() method was called with a map containing the user's data


### PR DESCRIPTION
Edit profile implentation added:
- refactor the Userinfo activity class to handle both Edit and Create modes
    - this means that when a user signs up, they are brought to that page in CREATE mode, and when they edit their profile, they are brought to that page in EDIT mode.
    
 - Allows users to remove their profiles from firebase and their profile, and to edit their names
 - Their deterministic profile picture is changed whenever they change their name too