### PR TITLE
Add Manage Media option in Nav Drawer for Admins

### DIFF
--- a/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
+++ b/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
@@ -80,7 +80,7 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
 
         // Make admin options available
         if (isAdmin) {
-            navigationView.getMenu().getItem(R.id.nav_manage_media).setVisible(true);
+            navigationView.getMenu().findItem(R.id.nav_manage_media).setVisible(true);
         }
 
         navigationView.setNavigationItemSelectedListener(this);

--- a/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
+++ b/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
@@ -43,6 +43,8 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_entrant_home);
 
+        final boolean isAdmin = getIntent().getBooleanExtra("IS_ADMIN", false);
+
         // Get device ID
         deviceId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
 
@@ -55,11 +57,17 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
         eventsLinearLayout = findViewById(R.id.eventsLinearLayout);
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+
         // Set up Navigation Drawer
         ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(
                 this, drawerLayout, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
         drawerLayout.addDrawerListener(toggle);
         toggle.syncState();
+
+        // Make admin options available
+        if (isAdmin) {
+            navigationView.getMenu().getItem(R.id.nav_manage_media).setVisible(true);
+        }
 
         navigationView.setNavigationItemSelectedListener(this);
 

--- a/app/src/main/java/com/example/potato1_events/LandingActivity.java
+++ b/app/src/main/java/com/example/potato1_events/LandingActivity.java
@@ -57,6 +57,8 @@ public class LandingActivity extends AppCompatActivity {
                         // User exists, navigate to the home activity
                         if (userType.equals("Entrant")) {
                             Intent intent = new Intent(LandingActivity.this, EntrantHomeActivity.class);
+                            boolean isAdmin = Boolean.parseBoolean(documentSnapshot.get("isAdmin").toString());
+                            intent.putExtra("IS_ADMIN", isAdmin);
                             startActivity(intent);
                         } else if (userType.equals("Organizer")) {
                             // Placeholder for OrganizerHomeActivity

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/nav_notifications"
         android:title="Notifications"
@@ -8,4 +9,11 @@
         android:id="@+id/nav_edit_profile"
         android:title="Edit Profile"
         android:icon="@drawable/ic_edit_profile" />
+    <item
+        android:id="@+id/nav_manage_media"
+        android:visible="false"
+        android:title="Manage Media"
+        android:icon="@android:drawable/ic_menu_gallery" />
 </menu>
+
+<!-- todo: change color of manage media icon to black -->


### PR DESCRIPTION
Created an additional Item in drawer_menu.xml for managing media ("Manage Media") that is set to visible or not visible programmatically depending on whether the current user has its user field isAdmin set to true or false. This required adding also a new field in each mock user in Firestore: "isAdmin".