### PR TITLE
added isAdmin field to user class to fix entrant bug

### DIFF
--- a/app/src/main/java/com/example/potato1_events/User.java
+++ b/app/src/main/java/com/example/potato1_events/User.java
@@ -19,11 +19,14 @@ public class User {
     private long createdAt; // Timestamp of account creation
     private long updatedAt; // Timestamp of last update
     private boolean isActive; // Indicates if the user account is active
+    private boolean isAdmin = false; // Indicates if the user has administrative privileges
 
     /**
      * Default constructor required for Firestore serialization.
+     * Initializes isAdmin to false by default.
      */
     public User() {
+        this.isAdmin = false;
     }
 
     /**
@@ -48,6 +51,7 @@ public class User {
         this.imagePath = imagePath;
         this.notificationsEnabled = notificationsEnabled;
         this.createdAt = createdAt;
+        this.isAdmin = false; // Ensure isAdmin is false by default
     }
 
     // Getters and Setters
@@ -194,5 +198,26 @@ public class User {
      */
     public void setCreatedAt(long createdAt) {
         this.createdAt = createdAt;
+    }
+    /**
+     * Checks if the user has administrative privileges.
+     * This field is intended to be managed directly in the database.
+     *
+     * @return True if the user is an admin, false otherwise.
+     */
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+
+    /**
+     * Sets the administrative status of the user.
+     * This method is private to prevent modification from application code.
+     * Only the database can modify this field.
+     *
+     * @param admin True to grant admin privileges, false to revoke.
+     */
+    @Exclude // Prevents this setter from being used by Firestore serialization
+    private void setAdmin(boolean admin) {
+        this.isAdmin = admin;
     }
 }


### PR DESCRIPTION
makes sure the user class has a isAdmin field with default False, only to be changed in firestore. Recreate user profile if your entrant page is crashing