### PR TITLE
Entrant statuses, date fixes, deletion propagation

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
+++ b/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
@@ -421,11 +421,12 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
         event.setStatus("Open");
         event.setCreatedAt(new Date());
 
-        // Initialize lists if null
-        event.setWaitingList(new ArrayList<>());
-        event.setSelectedEntrants(new ArrayList<>());
-        event.setConfirmedEntrants(new ArrayList<>());
-        event.setDeclinedEntrants(new ArrayList<>());
+        // Initialize entrants map
+        event.setEntrants(new HashMap<>());
+
+        event.setStartDate(startDateTime.getTime());
+        event.setEndDate(endDateTime.getTime());
+
 
         if (isEditingExistingEvent()) {
             // Update existing event
@@ -466,6 +467,7 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                     });
         }
     }
+
 
     /**
      * Adds the newly created event ID to the organizer's facility's eventIds list.

--- a/app/src/main/java/com/example/potato1_events/Event.java
+++ b/app/src/main/java/com/example/potato1_events/Event.java
@@ -2,7 +2,9 @@ package com.example.potato1_events;
 
 import com.google.firebase.firestore.ServerTimestamp;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents an Event that entrants can sign up for.
@@ -80,25 +82,8 @@ public class Event {
      */
     private String qrCodeHash;
 
-    /**
-     * List of entrant IDs in the waiting list.
-     */
-    private List<String> waitingList;
+    private Map<String, String> entrants; // Map of entrant IDs to their status
 
-    /**
-     * List of entrant IDs who have been selected.
-     */
-    private List<String> selectedEntrants;
-
-    /**
-     * List of entrant IDs who have confirmed their participation.
-     */
-    private List<String> confirmedEntrants;
-
-    /**
-     * List of entrant IDs who have declined the invitation.
-     */
-    private List<String> declinedEntrants;
 
     /**
      * Timestamp of when the event was created.
@@ -127,6 +112,7 @@ public class Event {
      */
     public Event() {
         // Default constructor
+        this.entrants = new HashMap<>();
     }
 
     /**
@@ -146,19 +132,16 @@ public class Event {
      * @param waitingListCapacity   Maximum entrants in the waiting list
      * @param posterImageUrl   URL of the poster image.
      * @param qrCodeHash       Hashed QR code data.
-     * @param waitingList      List of entrant IDs in waiting.
-     * @param selectedEntrants List of selected entrant IDs.
-     * @param confirmedEntrants List of confirmed entrant IDs.
-     * @param declinedEntrants List of declined entrant IDs.
+     * @param entrants       hashmap of entrants with field describing relation to event
      * @param createdAt        Creation timestamp.
      * @param status           Status of the event.
      * @param geolocationRequired  Switch enabling geolocation requirement.
      * @param eventLocation     Events location
      */
     public Event(String id, String facilityId, String name, String description, Date startDate, Date endDate,
-                 Date registrationStart, Date registrationEnd, double price, int capacity, int currentEntrantsNumber, int waitingListCapacity, String posterImageUrl,
-                 String qrCodeHash, List<String> waitingList, List<String> selectedEntrants,
-                 List<String> confirmedEntrants, List<String> declinedEntrants, Date createdAt, String status, boolean geolocationRequired, String eventLocation) {
+                 Date registrationStart, Date registrationEnd, double price, int capacity, int currentEntrantsNumber,
+                 int waitingListCapacity, String posterImageUrl, String qrCodeHash, Map<String, String> entrants,
+                 Date createdAt, String status, boolean geolocationRequired, String eventLocation) {
         this.id = id;
         this.facilityId = facilityId;
         this.name = name;
@@ -169,18 +152,17 @@ public class Event {
         this.registrationEnd = registrationEnd;
         this.price = price;
         this.capacity = capacity;
+        this.currentEntrantsNumber = currentEntrantsNumber;
         this.waitingListCapacity = waitingListCapacity;
         this.posterImageUrl = posterImageUrl;
         this.qrCodeHash = qrCodeHash;
-        this.waitingList = waitingList;
-        this.selectedEntrants = selectedEntrants;
-        this.confirmedEntrants = confirmedEntrants;
-        this.declinedEntrants = declinedEntrants;
+        this.entrants = entrants != null ? entrants : new HashMap<>();
         this.createdAt = createdAt;
         this.status = status;
         this.geolocationRequired = geolocationRequired;
         this.eventLocation = eventLocation;
     }
+
 
     // Getters and Setters
 
@@ -400,76 +382,42 @@ public class Event {
         this.qrCodeHash = qrCodeHash;
     }
 
+
     /**
-     * Gets the waiting list of entrant IDs.
+     * gets entrants hashmap.
      *
-     * @return Waiting list.
+     * @return entrants  hashmap of entrants with field describing relation to event
      */
-    public List<String> getWaitingList() {
-        return waitingList;
+    public Map<String, String> getEntrants() {
+        return entrants;
     }
 
     /**
-     * Sets the waiting list of entrant IDs.
+     * sets entrants hashmap.
      *
-     * @param waitingList Waiting list.
+     * @param entrants hashmap of entrants with field describing relation to event
      */
-    public void setWaitingList(List<String> waitingList) {
-        this.waitingList = waitingList;
+    public void setEntrants(Map<String, String> entrants) {
+        this.entrants = entrants;
     }
 
     /**
-     * Gets the list of selected entrant IDs.
+     * Adds or updates an entrant's status.
      *
-     * @return Selected entrants.
+     * @param entrantId The ID of the entrant.
+     * @param status    The status of the entrant (e.g., "enrolled", "selected", "confirmed", "declined").
      */
-    public List<String> getSelectedEntrants() {
-        return selectedEntrants;
+    public void updateEntrantStatus(String entrantId, String status) {
+        this.entrants.put(entrantId, status);
     }
 
     /**
-     * Sets the list of selected entrant IDs.
+     * Removes an entrant from the entrants map.
      *
-     * @param selectedEntrants Selected entrants.
+     * @param entrantId The ID of the entrant to remove.
      */
-    public void setSelectedEntrants(List<String> selectedEntrants) {
-        this.selectedEntrants = selectedEntrants;
-    }
-
-    /**
-     * Gets the list of confirmed entrant IDs.
-     *
-     * @return Confirmed entrants.
-     */
-    public List<String> getConfirmedEntrants() {
-        return confirmedEntrants;
-    }
-
-    /**
-     * Sets the list of confirmed entrant IDs.
-     *
-     * @param confirmedEntrants Confirmed entrants.
-     */
-    public void setConfirmedEntrants(List<String> confirmedEntrants) {
-        this.confirmedEntrants = confirmedEntrants;
-    }
-
-    /**
-     * Gets the list of declined entrant IDs.
-     *
-     * @return Declined entrants.
-     */
-    public List<String> getDeclinedEntrants() {
-        return declinedEntrants;
-    }
-
-    /**
-     * Sets the list of declined entrant IDs.
-     *
-     * @param declinedEntrants Declined entrants.
-     */
-    public void setDeclinedEntrants(List<String> declinedEntrants) {
-        this.declinedEntrants = declinedEntrants;
+    public void removeEntrant(String entrantId) {
+        this.entrants.remove(entrantId);
     }
 
     /**
@@ -508,50 +456,7 @@ public class Event {
         this.status = status;
     }
 
-    /**
-     * Adds an entrant ID to the waiting list.
-     *
-     * @param entrantId Entrant ID to add.
-     */
-    public void addToWaitingList(String entrantId) {
-        this.waitingList.add(entrantId);
-    }
 
-    /**
-     * Removes an entrant ID from the waiting list.
-     *
-     * @param entrantId Entrant ID to remove.
-     */
-    public void removeFromWaitingList(String entrantId) {
-        this.waitingList.remove(entrantId);
-    }
-
-    /**
-     * Adds an entrant ID to the selected entrants list.
-     *
-     * @param entrantId Entrant ID to add.
-     */
-    public void addSelectedEntrant(String entrantId) {
-        this.selectedEntrants.add(entrantId);
-    }
-
-    /**
-     * Adds an entrant ID to the confirmed entrants list.
-     *
-     * @param entrantId Entrant ID to add.
-     */
-    public void addConfirmedEntrant(String entrantId) {
-        this.confirmedEntrants.add(entrantId);
-    }
-
-    /**
-     * Adds an entrant ID to the declined entrants list.
-     *
-     * @param entrantId Entrant ID to add.
-     */
-    public void addDeclinedEntrant(String entrantId) {
-        this.declinedEntrants.add(entrantId);
-    }
 
     /**
      * Updates the event status.

--- a/app/src/main/java/com/example/potato1_events/ManageUsersActivity.java
+++ b/app/src/main/java/com/example/potato1_events/ManageUsersActivity.java
@@ -309,13 +309,14 @@ public class ManageUsersActivity extends AppCompatActivity {
         for (String eventId : eventsJoined) {
             DocumentReference eventRef = firestore.collection("Events").document(eventId);
 
-            eventRef.update("waitingList", FieldValue.arrayRemove(user.getUserId()))
+            eventRef.update("entrants." + user.getUserId(), FieldValue.delete())
                     .addOnSuccessListener(aVoid -> {
-                        Log.d(TAG, "Removed user from event waiting list: " + eventId);
+                        Log.d(TAG, "Removed " + user.getUserId() + " event waiting list: " + eventId);
                     })
                     .addOnFailureListener(e -> {
                         Log.e(TAG, "Error removing user from event " + eventId + ": " + e.getMessage(), e);
                     });
+            eventRef.update("currentEntrantsNumber", FieldValue.increment(-1));
         }
     }
 

--- a/app/src/main/java/com/example/potato1_events/ManageUsersActivity.java
+++ b/app/src/main/java/com/example/potato1_events/ManageUsersActivity.java
@@ -26,6 +26,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.storage.FirebaseStorage;
@@ -235,7 +236,15 @@ public class ManageUsersActivity extends AppCompatActivity {
      */
     private void deleteUser(User user) {
         String collection = "";
-        switch (user.getRole()) {
+        String role = user.getRole();
+
+        if (role == null) {
+            Toast.makeText(this, "User role is not specified.", Toast.LENGTH_SHORT).show();
+            Log.e(TAG, "User role is null for user: " + user.getUserId());
+            return;
+        }
+
+        switch (role) {
             case "Entrant":
                 collection = "Entrants";
                 break;
@@ -244,8 +253,8 @@ public class ManageUsersActivity extends AppCompatActivity {
                 break;
             // Optionally handle Admin or other roles
             default:
-                Toast.makeText(this, "Unknown user role: " + user.getRole(), Toast.LENGTH_SHORT).show();
-                Log.e(TAG, "Unknown user role: " + user.getRole());
+                Toast.makeText(this, "Unknown user role: " + role, Toast.LENGTH_SHORT).show();
+                Log.e(TAG, "Unknown user role: " + role);
                 return; // Exit the method as the role is unrecognized
         }
 
@@ -256,6 +265,9 @@ public class ManageUsersActivity extends AppCompatActivity {
             userRef.delete()
                     .addOnSuccessListener(aVoid -> {
                         Toast.makeText(ManageUsersActivity.this, "User deleted successfully.", Toast.LENGTH_SHORT).show();
+
+                        // Remove user from events' waiting lists
+                        removeUserFromEventsWaitingLists(user);
 
                         // Now, delete the profile image from Firebase Storage if it exists
                         if (!TextUtils.isEmpty(user.getImagePath())) {
@@ -280,4 +292,32 @@ public class ManageUsersActivity extends AppCompatActivity {
             Log.e(TAG, "Collection not determined for user: " + user.getUserId());
         }
     }
+
+    /**
+     * Removes the user from the waiting lists of the events they have joined.
+     *
+     * @param user The user to remove from events' waiting lists.
+     */
+    private void removeUserFromEventsWaitingLists(User user) {
+        List<String> eventsJoined = user.getEventsJoined();
+
+        if (eventsJoined == null || eventsJoined.isEmpty()) {
+            Log.d(TAG, "User has not joined any events.");
+            return;
+        }
+
+        for (String eventId : eventsJoined) {
+            DocumentReference eventRef = firestore.collection("Events").document(eventId);
+
+            eventRef.update("waitingList", FieldValue.arrayRemove(user.getUserId()))
+                    .addOnSuccessListener(aVoid -> {
+                        Log.d(TAG, "Removed user from event waiting list: " + eventId);
+                    })
+                    .addOnFailureListener(e -> {
+                        Log.e(TAG, "Error removing user from event " + eventId + ": " + e.getMessage(), e);
+                    });
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/example/potato1_events/User.java
+++ b/app/src/main/java/com/example/potato1_events/User.java
@@ -3,6 +3,9 @@ package com.example.potato1_events;
 import com.google.firebase.firestore.Exclude;
 import com.google.firebase.firestore.IgnoreExtraProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Represents a user within the Potato1 Events application.
  * This class includes all necessary information for entrants, organizers, and administrators.
@@ -22,12 +25,15 @@ public class User {
     private boolean isAdmin = false; // Indicates if the user has administrative privileges
     private String status; // Status related to event participation (e.g., Waiting List, Accepted, Rejected)
 
+    private List<String> eventsJoined; // List of event document IDs
+
     /**
      * Default constructor required for Firestore serialization.
      * Initializes isAdmin to false by default.
      */
     public User() {
         this.isAdmin = false;
+        this.eventsJoined = new ArrayList<>();
     }
 
     /**
@@ -53,6 +59,7 @@ public class User {
         this.notificationsEnabled = notificationsEnabled;
         this.createdAt = createdAt;
         this.isAdmin = false; // Ensure isAdmin is false by default
+        this.eventsJoined = new ArrayList<>();
     }
 
     // Getters and Setters
@@ -238,5 +245,23 @@ public class User {
      */
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    /**
+     * Gets the list of event IDs that the user has joined.
+     *
+     * @return A list of event document IDs.
+     */
+    public List<String> getEventsJoined() {
+        return eventsJoined;
+    }
+
+    /**
+     * Sets the list of event IDs that the user has joined.
+     *
+     * @param eventsJoined A list of event document IDs.
+     */
+    public void setEventsJoined(List<String> eventsJoined) {
+        this.eventsJoined = eventsJoined;
     }
 }

--- a/app/src/main/java/com/example/potato1_events/UserAdapter.java
+++ b/app/src/main/java/com/example/potato1_events/UserAdapter.java
@@ -7,40 +7,27 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
-
-// Import Firebase Storage
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
-
 import com.squareup.picasso.Picasso;
-
 import java.util.List;
+import java.util.Map;
 
-/**
- * Adapter for displaying users (entrants) in the waiting list.
- */
 public class UserAdapter extends RecyclerView.Adapter<UserAdapter.UserViewHolder> {
 
     private List<User> userList;
+    private Map<String, String> userStatusMap; // Map of user statuses keyed by userId
     private Context context;
 
-    /**
-     * Constructor for UserAdapter.
-     *
-     * @param userList The list of users to display.
-     * @param context  The context from the calling Activity.
-     */
-    public UserAdapter(List<User> userList, Context context) {
+    // Updated constructor to accept userStatusMap
+    public UserAdapter(List<User> userList, Map<String, String> userStatusMap, Context context) {
         this.userList = userList;
+        this.userStatusMap = userStatusMap;
         this.context = context;
     }
 
-    /**
-     * Inflates the entrant_item layout and returns a ViewHolder.
-     */
     @NonNull
     @Override
     public UserViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -48,35 +35,22 @@ public class UserAdapter extends RecyclerView.Adapter<UserAdapter.UserViewHolder
         return new UserViewHolder(userView);
     }
 
-    /**
-     * Binds user data to the UI components.
-     */
     @Override
     public void onBindViewHolder(@NonNull UserViewHolder holder, int position) {
         User user = userList.get(position);
         holder.bind(user);
     }
 
-    /**
-     * Returns the total number of users in the list.
-     */
     @Override
     public int getItemCount() {
         return userList.size();
     }
 
-    /**
-     * ViewHolder class for user items.
-     */
     class UserViewHolder extends RecyclerView.ViewHolder {
-
         ImageView entrantProfileImageView;
         TextView entrantNameTextView;
         TextView entrantStatusTextView;
 
-        /**
-         * Initializes the UI components for each list item.
-         */
         public UserViewHolder(@NonNull View itemView) {
             super(itemView);
             entrantProfileImageView = itemView.findViewById(R.id.entrantProfileImageView);
@@ -84,26 +58,16 @@ public class UserAdapter extends RecyclerView.Adapter<UserAdapter.UserViewHolder
             entrantStatusTextView = itemView.findViewById(R.id.entrantStatusTextView);
         }
 
-        /**
-         * Binds the user data to the UI components.
-         *
-         * @param user The User object containing entrant details.
-         */
         public void bind(User user) {
-            // Load profile image using Firebase Storage
+            // Load profile image
             if (!TextUtils.isEmpty(user.getImagePath())) {
                 StorageReference imageRef = FirebaseStorage.getInstance().getReference().child(user.getImagePath());
                 imageRef.getDownloadUrl()
-                        .addOnSuccessListener(uri -> {
-                            Picasso.get()
-                                    .load(uri)
-                                    .placeholder(R.drawable.ic_placeholder_image)
-                                    .error(R.drawable.ic_error_image)
-                                    .into(entrantProfileImageView);
-                        })
-                        .addOnFailureListener(e -> {
-                            entrantProfileImageView.setImageResource(R.drawable.ic_error_image);
-                        });
+                        .addOnSuccessListener(uri -> Picasso.get().load(uri)
+                                .placeholder(R.drawable.ic_placeholder_image)
+                                .error(R.drawable.ic_error_image)
+                                .into(entrantProfileImageView))
+                        .addOnFailureListener(e -> entrantProfileImageView.setImageResource(R.drawable.ic_error_image));
             } else {
                 entrantProfileImageView.setImageResource(R.drawable.ic_placeholder_image);
             }
@@ -111,9 +75,9 @@ public class UserAdapter extends RecyclerView.Adapter<UserAdapter.UserViewHolder
             // Set entrant name
             entrantNameTextView.setText(user.getName() != null ? user.getName() : "Unnamed Entrant");
 
-            // Set entrant status
-            String statusText = "Status: " + (user.getStatus() != null ? user.getStatus() : "Unknown");
-            entrantStatusTextView.setText(statusText);
+            // Retrieve and set entrant status from the map using userId
+            String status = userStatusMap.getOrDefault(user.getUserId(), "Unknown");
+            entrantStatusTextView.setText("Status: " + status);
         }
     }
 }

--- a/app/src/main/java/com/example/potato1_events/UserInfoActivity.java
+++ b/app/src/main/java/com/example/potato1_events/UserInfoActivity.java
@@ -1,3 +1,4 @@
+// File: UserInfoActivity.java
 package com.example.potato1_events;
 
 import android.Manifest;
@@ -153,14 +154,8 @@ public class UserInfoActivity extends AppCompatActivity {
 
         saveButton.setOnClickListener(v -> saveUserInfo());
 
-        // If in EDIT mode, load existing user data
-        if (mode.equals(MODE_EDIT)) {
-            loadUserData();
-        } else {
-            // In CREATE mode, set default UI state
-            generateAndSetDefaultAvatar("");
-            uploadRemovePictureButton.setText("Upload Picture");
-        }
+        // Load user data or set up for new user
+        loadOrInitializeUserData();
     }
 
     /**
@@ -185,13 +180,15 @@ public class UserInfoActivity extends AppCompatActivity {
     }
 
     /**
-     * Loads the existing user data from Firestore and pre-fills the input fields.
+     * Loads the existing user data from Firestore or initializes for a new user.
      */
-    private void loadUserData() {
+    private void loadOrInitializeUserData() {
         saveButton.setEnabled(false); // Disable save button while loading
         firestore.collection(userType + "s").document(deviceId).get()
                 .addOnSuccessListener(documentSnapshot -> {
                     if (documentSnapshot.exists()) {
+                        // User data exists, proceed in EDIT mode
+                        mode = MODE_EDIT;
                         User user = documentSnapshot.toObject(User.class);
                         if (user != null) {
                             nameEditText.setText(user.getName());
@@ -220,8 +217,11 @@ public class UserInfoActivity extends AppCompatActivity {
                             }
                         }
                     } else {
-                        Toast.makeText(UserInfoActivity.this, "User data not found.", Toast.LENGTH_SHORT).show();
-                        finish();
+                        // User data does not exist, proceed in CREATE mode
+                        mode = MODE_CREATE;
+                        // In CREATE mode, set default UI state
+                        generateAndSetDefaultAvatar("");
+                        uploadRemovePictureButton.setText("Upload Picture");
                     }
                     saveButton.setEnabled(true);
                 })
@@ -269,20 +269,17 @@ public class UserInfoActivity extends AppCompatActivity {
                 // No existing image to delete, generate and upload default avatar
                 generateAndUploadDefaultAvatar(name, email, phoneNumber);
             }
-        }
-        else if (selectedImageUri != null) {
+        } else if (selectedImageUri != null) {
             // Handle new image selected
             uploadImageToFirebase(name, email, phoneNumber);
-        }
-        else {
+        } else {
             // No changes to profile picture
             if (mode.equals(MODE_CREATE)) {
                 // In CREATE mode, generate and upload default avatar
                 generateAndUploadDefaultAvatar(name, email, phoneNumber);
-            }
-            else {
+            } else {
                 // In EDIT mode, keep existing image (if any)
-                updateUserInFirestore(name, email, phoneNumber, existingImagePath);
+                saveOrUpdateUserInFirestore(name, email, phoneNumber, existingImagePath);
             }
         }
     }
@@ -312,7 +309,7 @@ public class UserInfoActivity extends AppCompatActivity {
                                 .addOnSuccessListener(aVoid -> {
                                     Log.d(TAG, "Existing image deleted successfully.");
                                     // Update Firestore with new image path
-                                    updateUserInFirestore(name, email, phoneNumber, imagePath);
+                                    saveOrUpdateUserInFirestore(name, email, phoneNumber, imagePath);
                                 })
                                 .addOnFailureListener(e -> {
                                     Toast.makeText(UserInfoActivity.this, "Failed to delete existing image: " + e.getMessage(), Toast.LENGTH_SHORT).show();
@@ -321,7 +318,7 @@ public class UserInfoActivity extends AppCompatActivity {
                                 });
                     } else {
                         // No existing image, update Firestore with new image path
-                        updateUserInFirestore(name, email, phoneNumber, imagePath);
+                        saveOrUpdateUserInFirestore(name, email, phoneNumber, imagePath);
                     }
                 })
                 .addOnFailureListener(e -> {
@@ -330,51 +327,6 @@ public class UserInfoActivity extends AppCompatActivity {
                     saveButton.setEnabled(true);
                 });
     }
-
-    /**
-     * Updates the user's information in Firestore without altering the eventsJoined list.
-     *
-     * @param name        The user's name.
-     * @param email       The user's email address.
-     * @param phoneNumber The user's phone number.
-     * @param imagePath   The image path to save (can be null).
-     */
-    private void updateUserInFirestore(String name, String email, String phoneNumber, String imagePath) {
-        firestore.collection(userType + "s").document(deviceId).get()
-                .addOnSuccessListener(documentSnapshot -> {
-                    if (documentSnapshot.exists()) {
-                        User user = documentSnapshot.toObject(User.class);
-                        if (user != null) {
-
-                            // Update fields with new values
-                            user.setName(name);
-                            user.setEmail(email);
-                            user.setPhoneNumber(phoneNumber);
-                            user.setImagePath(imagePath);
-
-                            // Save back to Firestore
-                            firestore.collection(userType + "s").document(deviceId)
-                                    .set(user)
-                                    .addOnSuccessListener(aVoid -> {
-                                        Toast.makeText(UserInfoActivity.this, "Profile updated successfully", Toast.LENGTH_SHORT).show();
-                                        navigateToHomePage();
-                                    })
-                                    .addOnFailureListener(e -> {
-                                        Toast.makeText(UserInfoActivity.this, "Error updating profile: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                                        Log.e(TAG, "Error updating profile", e);
-                                        saveButton.setEnabled(true);
-                                    });
-                        }
-                    } else {
-                        Toast.makeText(UserInfoActivity.this, "User data not found.", Toast.LENGTH_SHORT).show();
-                    }
-                })
-                .addOnFailureListener(e -> {
-                    Toast.makeText(UserInfoActivity.this, "Error loading user data: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                    Log.e(TAG, "Error loading user data", e);
-                });
-    }
-
 
     /**
      * Generates a default avatar, uploads it to Firebase Storage, and updates Firestore.
@@ -405,13 +357,61 @@ public class UserInfoActivity extends AppCompatActivity {
                     // Get the storage path
                     String avatarPath = storageRef.getPath();
                     // Update Firestore with new default avatar path
-                    updateUserInFirestore(name, email, phoneNumber, avatarPath);
+                    saveOrUpdateUserInFirestore(name, email, phoneNumber, avatarPath);
                 })
                 .addOnFailureListener(e -> {
                     Toast.makeText(UserInfoActivity.this, "Default avatar upload failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                     Log.e(TAG, "Default avatar upload failed", e);
                     saveButton.setEnabled(true);
                 });
+    }
+
+    /**
+     * Saves or updates the user's information in Firestore.
+     *
+     * @param name        The user's name.
+     * @param email       The user's email address.
+     * @param phoneNumber The user's phone number.
+     * @param imagePath   The image path to save (can be null).
+     */
+    private void saveOrUpdateUserInFirestore(String name, String email, String phoneNumber, String imagePath) {
+        User user = new User();
+        user.setUserId(deviceId); // Assign device ID as userId
+        user.setName(name);
+        user.setEmail(email);
+        user.setPhoneNumber(phoneNumber);
+        user.setImagePath(imagePath);
+        user.setRole(userType);
+        if (mode.equals(MODE_CREATE)) {
+            // Initialize eventsJoined list for new users
+            user.setEventsJoined(new ArrayList<>());
+
+            // Save new user to Firestore
+            firestore.collection(userType + "s").document(deviceId)
+                    .set(user)
+                    .addOnSuccessListener(aVoid -> {
+                        Toast.makeText(UserInfoActivity.this, "Profile created successfully", Toast.LENGTH_SHORT).show();
+                        navigateToHomePage();
+                    })
+                    .addOnFailureListener(e -> {
+                        Toast.makeText(UserInfoActivity.this, "Error creating profile: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                        Log.e(TAG, "Error creating profile", e);
+                        saveButton.setEnabled(true);
+                    });
+        } else {
+            // Update existing user in Firestore
+            firestore.collection(userType + "s").document(deviceId)
+                    .set(user)
+                    .addOnSuccessListener(aVoid -> {
+                        Toast.makeText(UserInfoActivity.this, "Profile updated successfully", Toast.LENGTH_SHORT).show();
+                        navigateToHomePage();
+                    })
+                    .addOnFailureListener(e -> {
+                        Toast.makeText(UserInfoActivity.this, "Error updating profile: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                        Log.e(TAG, "Error updating profile", e);
+                        saveButton.setEnabled(true);
+                    });
+        }
     }
 
     /**


### PR DESCRIPTION
Pretty much title

refactored events to hold a hashmap of entrants with their status as the value. TODO: Refactor a bit more later to include geolocation underneath the userID. 

- Fixed display to show the status of the entrant
- Fixed way dates wer saved and fixed displaying dates in menus
- Admins may now browse all profiles and delete entrants, propagating their deletion and removing them from events they have joined