### PR TITLE
added admin browse events to delete events and QR hash data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ManageEventsActivity" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
+++ b/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
@@ -37,7 +37,6 @@ import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.WriterException;
-import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.qrcode.QRCodeWriter;
 import com.squareup.picasso.Picasso;
 
@@ -82,6 +81,7 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
 
     // User Privileges
     private boolean isAdmin = false; // Retrieved from Intent
+    private String qrCodeHash = null; // To track QR code hash
 
     /**
      * Sets the Firestore instance for testing purposes.
@@ -193,9 +193,19 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                 requestPermissionLauncher.launch(getReadPermission());
             }
         });
-        saveEventButton.setOnClickListener(v -> saveEvent()); // Handle QR code generation internally
+        saveEventButton.setOnClickListener(v -> saveEvent());
         deleteEventButton.setOnClickListener(v -> confirmDeleteEvent());
-        generateQRCodeButton.setOnClickListener(v -> generateQRCode()); // Set up Generate QR Code button listener
+
+        // Set up Generate QR Code button listener
+        generateQRCodeButton.setOnClickListener(v -> {
+            if (generateQRCodeButton.getText().toString().equalsIgnoreCase("Generate QR Code")) {
+                // Generate QR Code
+                generateQRCode();
+            } else if (generateQRCodeButton.getText().toString().equalsIgnoreCase("Remove QR Code")) {
+                // Remove QR Code
+                removeQRCode();
+            }
+        });
 
         // Check if editing an existing event
         Intent intent = getIntent();
@@ -203,10 +213,11 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
             eventId = intent.getStringExtra("EVENT_ID");
             loadEventData(eventId);
             deleteEventButton.setVisibility(View.VISIBLE); // Show delete button in edit mode
-            generateQRCodeButton.setVisibility(View.GONE); // Hide generate QR code button in edit mode
+            // The visibility and text of generateQRCodeButton will be handled in loadEventData()
         } else {
             deleteEventButton.setVisibility(View.GONE); // Hide delete button in create mode
             generateQRCodeButton.setVisibility(View.VISIBLE); // Show generate QR code button in create mode
+            generateQRCodeButton.setText("Generate QR Code"); // Ensure correct initial text
         }
 
         // Verify that the organizer has a facility before allowing event creation
@@ -424,11 +435,11 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
         } else {
             // If editing and no new image is selected, keep the last image
             if (isEditingExistingEvent()) {
-                // Preserve existing posterImageUrl and QR code hash
-                saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterImageUrl, null);
+                // Preserve existing posterImageUrl and handle QR code hash based on user action
+                saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterImageUrl);
             } else {
                 // Proceed to save event without poster image
-                saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, null, null);
+                saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, null);
             }
         }
     }
@@ -456,7 +467,7 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                     storageRef.getDownloadUrl().addOnSuccessListener(uri -> {
                         posterImageUrl = uri.toString();
                         // Proceed to save the event with the poster URL
-                        generateQRCodeAndSaveEvent(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterImageUrl);
+                        saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterImageUrl);
                     }).addOnFailureListener(e -> {
                         Toast.makeText(CreateEditEventActivity.this, "Failed to get poster URL: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                         saveEventButton.setEnabled(true);
@@ -469,28 +480,83 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
     }
 
     /**
-     * Generates a QR code for the event and proceeds to save the event data to Firestore.
+     * Generates a QR code based on the provided hash and displays it in the UI.
      *
-     * @param name                 Event name.
-     * @param description          Event description.
-     * @param location             Event location.
-     * @param availableSpots       Number of available spots.
-     * @param waitingListSpots     Number of waiting list spots (can be null for unlimited).
-     * @param isGeolocationEnabled Whether geolocation is enabled.
-     * @param posterUrl            URL of the uploaded poster image.
+     * @param qrHash The data to encode in the QR code (typically the event ID).
      */
-    private void generateQRCodeAndSaveEvent(String name, String description, String location,
-                                            int availableSpots, Integer waitingListSpots,
-                                            boolean isGeolocationEnabled, String posterUrl) {
+    private void generateQRCodeAndDisplay(String qrHash) {
+        // Define the data to be encoded in the QR code (using qrHash)
+        String qrData = qrHash;
 
+        // Generate QR code bitmap
+        QRCodeWriter qrCodeWriter = new QRCodeWriter();
+        int size = 512; // Size of the QR code image
+
+        Bitmap qrBitmap;
+        try {
+            com.google.zxing.common.BitMatrix bitMatrix = qrCodeWriter.encode(qrData, BarcodeFormat.QR_CODE, size, size);
+            qrBitmap = Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565);
+
+            for (int x = 0; x < size; x++) {
+                for (int y = 0; y < size; y++) {
+                    qrBitmap.setPixel(x, y, bitMatrix.get(x, y) ? Color.BLACK : Color.WHITE);
+                }
+            }
+        } catch (WriterException e) {
+            Toast.makeText(this, "Failed to generate QR code: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+            saveEventButton.setEnabled(true);
+            return;
+        }
+
+        // Display the QR code in the UI
+        qrCodeImageView.setImageBitmap(qrBitmap);
+        qrCodeImageView.setVisibility(View.VISIBLE); // Make the QR code visible
+
+        Toast.makeText(this, "QR code generated!", Toast.LENGTH_SHORT).show();
+    }
+
+    /**
+     * Generates a QR code and handles its state based on whether it's being generated or removed.
+     */
+    private void generateQRCode() {
         if (isEditingExistingEvent()) {
-            // **Editing Existing Event: Use Existing QR Code Hash**
-            // No need to regenerate QR code; proceed to save updates
-            saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterUrl, null);
+            if (qrCodeHash == null) {
+                // Generate QR code hash based on eventId
+                if (eventId == null) {
+                    // eventId should already be set when editing
+                    Toast.makeText(this, "Invalid event ID.", Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                qrCodeHash = eventId;
+                generateQRCodeAndDisplay(qrCodeHash);
+                generateQRCodeButton.setText("Remove QR Code");
+            } else {
+                Toast.makeText(this, "QR code already exists.", Toast.LENGTH_SHORT).show();
+            }
         } else {
-            // **Creating New Event: Generate QR Code After Event Creation**
-            // Since QR code generation requires the event ID, proceed to create the event first.
-            saveEventToFirestore(name, description, location, availableSpots, waitingListSpots, isGeolocationEnabled, posterUrl, null);
+            // Creating a new event; QR code will be generated after saving
+            Toast.makeText(this, "Please save the event first to generate a QR code.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Removes the QR code from the UI and clears the qrCodeHash.
+     */
+    private void removeQRCode() {
+        if (isEditingExistingEvent() && qrCodeHash != null) {
+            // Remove the QR code image
+            qrCodeImageView.setImageBitmap(null);
+            qrCodeImageView.setVisibility(View.GONE);
+
+            // Clear the qrCodeHash
+            qrCodeHash = null;
+
+            // Update button text back to "Generate QR Code"
+            generateQRCodeButton.setText("Generate QR Code");
+
+            Toast.makeText(this, "QR code removed.", Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, "No QR code to remove.", Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -504,11 +570,10 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
      * @param waitingListSpots     Number of waiting list spots (can be null for unlimited).
      * @param isGeolocationEnabled Whether geolocation is enabled.
      * @param posterUrl            URL of the uploaded poster image.
-     * @param qrCodeHash           QR code hash data. If null, it will be generated after event creation.
      */
     private void saveEventToFirestore(String name, String description, String location,
                                       int availableSpots, Integer waitingListSpots,
-                                      boolean isGeolocationEnabled, String posterUrl, String qrCodeHash) {
+                                      boolean isGeolocationEnabled, String posterUrl) {
 
         if (isEditingExistingEvent()) {
             // **Editing an Existing Event**
@@ -529,6 +594,13 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
             updates.put("startDate", startDateTime.getTime());
             updates.put("endDate", endDateTime.getTime());
             updates.put("registrationEnd", registrationEndDateTime.getTime());
+
+            // Handle QR code hash
+            if (qrCodeHash != null) {
+                updates.put("qrCodeHash", qrCodeHash);
+            } else {
+                updates.put("qrCodeHash", FieldValue.delete()); // Remove the QR code hash from Firestore
+            }
 
             // Update only the specified fields to preserve entrants and other data
             firestore.collection("Events").document(eventId).update(updates)
@@ -567,32 +639,27 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
             eventData.put("endDate", endDateTime.getTime());
             eventData.put("registrationEnd", registrationEndDateTime.getTime());
             eventData.put("randomDrawPerformed", false); // Ensure this is set to false during creation
+
+            if (qrCodeHash != null) {
+                eventData.put("qrCodeHash", qrCodeHash);
+            }
+
             eventData.put("waitingListFilled", false);
             // Create a new event document
             firestore.collection("Events").add(eventData)
                     .addOnSuccessListener(documentReference -> {
                         String eventIdCreated = documentReference.getId();
 
-                        if (qrCodeHash == null) {
-                            // Generate the QR code hash using the event ID
-                            String qrHash = eventIdCreated; // Simple approach: use eventId as QR hash
-
-                            // Update the event with the QR code hash
-                            firestore.collection("Events").document(eventIdCreated).update("qrCodeHash", qrHash)
-                                    .addOnSuccessListener(aVoid -> {
-                                        Toast.makeText(CreateEditEventActivity.this, "Event created successfully!", Toast.LENGTH_SHORT).show();
-                                        // Add eventId to the facility's eventIds list
-                                        addEventToFacility(eventIdCreated);
-                                        // Optionally, generate and display the QR code
-                                        generateQRCodeAndDisplay(qrHash);
-                                    })
-                                    .addOnFailureListener(e -> {
-                                        Toast.makeText(CreateEditEventActivity.this, "Failed to set QR code hash: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                                        saveEventButton.setEnabled(true);
-                                    });
-                        } else {
-                            // If QR code hash is provided (unlikely in create), proceed normally
+                        if (qrCodeHash != null) {
+                            // QR code has been generated; already set in eventData
+                            // Add eventId to the facility's eventIds list
                             addEventToFacility(eventIdCreated);
+                            navigateBackToEventList();
+                        } else {
+                            // QR code not generated yet
+                            // Add eventId to the facility's eventIds list
+                            addEventToFacility(eventIdCreated);
+                            navigateBackToEventList();
                         }
                     })
                     .addOnFailureListener(e -> {
@@ -600,42 +667,6 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                         saveEventButton.setEnabled(true);
                     });
         }
-    }
-
-    /**
-     * Generates a QR code based on the provided hash and displays it in the UI.
-     *
-     * @param qrHash The data to encode in the QR code (typically the event ID).
-     */
-    private void generateQRCodeAndDisplay(String qrHash) {
-        // Define the data to be encoded in the QR code (using qrHash)
-        String qrData = qrHash;
-
-        // Generate QR code bitmap
-        QRCodeWriter qrCodeWriter = new QRCodeWriter();
-        int size = 512; // Size of the QR code image
-
-        Bitmap qrBitmap;
-        try {
-            com.google.zxing.common.BitMatrix bitMatrix = qrCodeWriter.encode(qrData, BarcodeFormat.QR_CODE, size, size);
-            qrBitmap = Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565);
-
-            for (int x = 0; x < size; x++) {
-                for (int y = 0; y < size; y++) {
-                    qrBitmap.setPixel(x, y, bitMatrix.get(x, y) ? Color.BLACK : Color.WHITE);
-                }
-            }
-        } catch (WriterException e) {
-            Toast.makeText(this, "Failed to generate QR code: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-            saveEventButton.setEnabled(true);
-            return;
-        }
-
-        // Display the QR code in the UI
-        qrCodeImageView.setImageBitmap(qrBitmap);
-        qrCodeImageView.setVisibility(View.VISIBLE); // Make the QR code visible
-
-        Toast.makeText(this, "QR code generated!", Toast.LENGTH_SHORT).show();
     }
 
     /**
@@ -737,11 +768,14 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                             uploadPosterButton.setText("Change Poster Image"); // Update button text
                         }
 
-                        // Store existing QR code hash
-                        // In this implementation, qrCodeHash is the event ID
+                        // Store existing QR code hash and update button accordingly
                         if (!TextUtils.isEmpty(qrCodeHashFetched)) {
-                            // Optionally, display the QR code if desired
+                            qrCodeHash = qrCodeHashFetched;
                             generateQRCodeAndDisplay(qrCodeHashFetched);
+                            generateQRCodeButton.setText("Remove QR Code");
+                        } else {
+                            qrCodeHash = null;
+                            generateQRCodeButton.setText("Generate QR Code");
                         }
 
                         // Handle unlimited waiting list based on waitingListCapacity being null
@@ -754,6 +788,9 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                             waitingListSpotsEditText.setEnabled(true);
                         }
 
+                        // Ensure the generateQRCodeButton is visible in edit mode
+                        generateQRCodeButton.setVisibility(View.VISIBLE);
+
                     } else {
                         Toast.makeText(this, "Event not found.", Toast.LENGTH_SHORT).show();
                         finish();
@@ -765,29 +802,6 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                 });
     }
 
-    /**
-     * Generates QR code when the button is clicked.
-     */
-    private void generateQRCode() {
-        // In this implementation, QR code is generated after event creation
-        // So, when the user clicks "Generate QR Code", it saves the event first
-        // and then generates the QR code based on the event ID
-        saveEvent();
-    }
-
-    /**
-     * Initiates the QR code scanning using ZXing library.
-     */
-    private void scanQRCode() {
-        IntentIntegrator integrator = new IntentIntegrator(this);
-        integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE);
-        integrator.setPrompt("Scan a QR Code");
-        integrator.setOrientationLocked(true);  // Lock orientation to portrait
-        integrator.setCaptureActivity(PortraitCaptureActivity.class);
-        integrator.setBeepEnabled(true);
-        integrator.setBarcodeImageEnabled(true);
-        integrator.initiateScan();
-    }
 
     /**
      * Confirms with the user before deleting the event.

--- a/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
+++ b/app/src/main/java/com/example/potato1_events/EntrantHomeActivity.java
@@ -103,6 +103,7 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
         if (isAdmin) {
             navigationView.getMenu().findItem(R.id.nav_manage_media).setVisible(true);
             navigationView.getMenu().findItem(R.id.nav_manage_users).setVisible(true);
+            navigationView.getMenu().findItem(R.id.nav_manage_events).setVisible(true);
             navigationView.getMenu().findItem(R.id.nav_create_event).setVisible(true);
             navigationView.getMenu().findItem(R.id.nav_edit_facility).setVisible(true);
             navigationView.getMenu().findItem(R.id.nav_my_events).setVisible(true);
@@ -264,6 +265,8 @@ public class EntrantHomeActivity extends AppCompatActivity implements Navigation
         } else if (id == R.id.nav_manage_users) {
             // Navigate to ManageUsersActivity (visible only to admins)
             intent = new Intent(EntrantHomeActivity.this, ManageUsersActivity.class);
+        } else if (id == R.id.nav_manage_events) {
+            intent = new Intent(EntrantHomeActivity.this, ManageEventsActivity.class);
         } else if (id == R.id.action_scan_qr) {
             intent = new Intent(EntrantHomeActivity.this, QRScanActivity.class);
         } else if (id == R.id.nav_create_event) {

--- a/app/src/main/java/com/example/potato1_events/ManageEventsActivity.java
+++ b/app/src/main/java/com/example/potato1_events/ManageEventsActivity.java
@@ -1,0 +1,307 @@
+// File: ManageEventsActivity.java
+package com.example.potato1_events;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.storage.FirebaseStorage;
+import com.squareup.picasso.Picasso;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Activity for admins to manage events.
+ * Allows viewing, deleting entire events, or deleting QR code hash data from event documents.
+ */
+public class ManageEventsActivity extends AppCompatActivity {
+
+    // UI Components
+    private RecyclerView eventsRecyclerView;
+    private EventsAdapter eventsAdapter;
+    private List<Event> eventList;
+
+    // Firebase Firestore
+    private FirebaseFirestore firestore;
+
+    // Tag for logging
+    private static final String TAG = "ManageEventsActivity";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_manage_events);
+
+        // Initialize Firestore
+        firestore = FirebaseFirestore.getInstance();
+
+        // Initialize UI Components
+        Toolbar toolbar = findViewById(R.id.toolbar_manage_events);
+        setSupportActionBar(toolbar);
+
+        // Enable the Up button for navigation
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        // Initialize RecyclerView
+        eventsRecyclerView = findViewById(R.id.eventsRecyclerView);
+        eventsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        eventsRecyclerView.setHasFixedSize(true);
+
+        // Initialize event list and adapter
+        eventList = new ArrayList<>();
+        eventsAdapter = new EventsAdapter(eventList);
+        eventsRecyclerView.setAdapter(eventsAdapter);
+
+        // Load events from Firestore
+        loadEvents();
+    }
+
+    /**
+     * Loads all events from the "Events" collection in Firestore.
+     * Populates the RecyclerView with the fetched event data.
+     */
+    private void loadEvents() {
+        CollectionReference eventsRef = firestore.collection("Events");
+
+        // Fetch all events from the "Events" collection
+        eventsRef.get()
+                .addOnSuccessListener(querySnapshot -> {
+                    eventList.clear(); // Clear existing events to avoid duplication
+
+                    for (DocumentSnapshot doc : querySnapshot) {
+                        Event event = doc.toObject(Event.class);
+                        if (event != null) {
+                            // Ensure the event ID is set
+                            event.setId(doc.getId());
+                            eventList.add(event);
+                        }
+                    }
+
+                    eventsAdapter.notifyDataSetChanged(); // Refresh the RecyclerView
+
+                    if (eventList.isEmpty()) {
+                        Toast.makeText(ManageEventsActivity.this, "No events found.", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(ManageEventsActivity.this, "Loaded Events: " + eventList.size(), Toast.LENGTH_SHORT).show();
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(ManageEventsActivity.this, "Error loading events: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Error loading events", e);
+                });
+    }
+
+    /**
+     * Handles the selection of menu items in the action bar.
+     * Specifically handles the Up button to navigate back to the parent activity.
+     *
+     * @param item The selected menu item.
+     * @return True if the event was handled, false otherwise.
+     */
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        // Handle Up button presses
+        if (item.getItemId() == android.R.id.home) {
+            finish(); // Closes the current activity and returns to the parent
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * Adapter class for managing and displaying a list of events in the RecyclerView.
+     * Binds event data to the UI components and handles admin interactions such as deletion.
+     */
+    private class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.EventViewHolder> {
+
+        private List<Event> events;
+
+        EventsAdapter(List<Event> events) {
+            this.events = events;
+        }
+
+        @NonNull
+        @Override
+        public EventViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            // Inflate the item_event layout
+            View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.manage_event_item, parent, false);
+            return new EventViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
+            Event event = events.get(position);
+
+            // Bind event data to TextViews
+            holder.eventNameTextView.setText(event.getName());
+            holder.eventLocationTextView.setText("Location: " + event.getEventLocation());
+
+            // Load event poster image
+            if (!TextUtils.isEmpty(event.getPosterImageUrl())) {
+                // Use Picasso or any other image loading library
+                Picasso.get()
+                        .load(event.getPosterImageUrl())
+                        .placeholder(R.drawable.ic_placeholder_image)
+                        .error(R.drawable.ic_error_image)
+                        .into(holder.eventPosterImageView);
+            } else {
+                holder.eventPosterImageView.setImageResource(R.drawable.ic_placeholder_image);
+            }
+
+            // Set Delete QR Code Button Listener
+            holder.deleteQrButton.setOnClickListener(v -> {
+                confirmDeleteQrCode(event);
+            });
+
+            // Set Delete Event Button Listener
+            holder.deleteEventButton.setOnClickListener(v -> {
+                confirmDeleteEvent(event);
+            });
+        }
+
+        @Override
+        public int getItemCount() {
+            return events.size();
+        }
+
+        /**
+         * ViewHolder class for holding and recycling event item views.
+         * Caches references to the UI components for each event item to improve performance.
+         */
+        class EventViewHolder extends RecyclerView.ViewHolder {
+
+            ImageView eventPosterImageView;
+            TextView eventNameTextView;
+            TextView eventLocationTextView;
+            Button deleteQrButton;
+            Button deleteEventButton;
+
+            EventViewHolder(@NonNull View itemView) {
+                super(itemView);
+                eventPosterImageView = itemView.findViewById(R.id.eventPosterImageView);
+                eventNameTextView = itemView.findViewById(R.id.eventNameTextView);
+                eventLocationTextView = itemView.findViewById(R.id.eventLocationTextView);
+                deleteQrButton = itemView.findViewById(R.id.deleteQrButton);
+                deleteEventButton = itemView.findViewById(R.id.deleteEventButton);
+            }
+        }
+    }
+
+    /**
+     * Prompts the admin to confirm deletion of the QR code hash data for an event.
+     *
+     * @param event The Event object whose QR code hash is to be deleted.
+     */
+    private void confirmDeleteQrCode(Event event) {
+        new AlertDialog.Builder(this)
+                .setTitle("Delete QR Code Hash")
+                .setMessage("Are you sure you want to delete the QR code hash for this event?")
+                .setPositiveButton("Yes", (dialog, which) -> deleteQrCodeHash(event))
+                .setNegativeButton("No", null)
+                .show();
+    }
+
+    /**
+     * Deletes the QR code hash from the specified event document in Firestore.
+     *
+     * @param event The Event object whose QR code hash is to be deleted.
+     */
+    private void deleteQrCodeHash(Event event) {
+        if (event == null || TextUtils.isEmpty(event.getId())) {
+            Toast.makeText(this, "Invalid event data.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        DocumentReference eventRef = firestore.collection("Events").document(event.getId());
+
+        // Update the qrCodeHash field to null or remove it
+        eventRef.update("qrCodeHash", null)
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, "QR code hash deleted successfully.", Toast.LENGTH_SHORT).show();
+                    loadEvents(); // Refresh the event list
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(this, "Error deleting QR code hash: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Error deleting QR code hash", e);
+                });
+    }
+
+    /**
+     * Prompts the admin to confirm deletion of an entire event.
+     *
+     * @param event The Event object to delete.
+     */
+    private void confirmDeleteEvent(Event event) {
+        new AlertDialog.Builder(this)
+                .setTitle("Delete Event")
+                .setMessage("Are you sure you want to delete this entire event? This action cannot be undone.")
+                .setPositiveButton("Yes", (dialog, which) -> deleteEvent(event))
+                .setNegativeButton("No", null)
+                .show();
+    }
+
+    /**
+     * Deletes the specified event from Firestore.
+     * Also handles deletion of associated QR code images from Firebase Storage if applicable.
+     *
+     * @param event The Event object to delete.
+     */
+    private void deleteEvent(Event event) {
+        if (event == null || TextUtils.isEmpty(event.getId())) {
+            Toast.makeText(this, "Invalid event data.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        DocumentReference eventRef = firestore.collection("Events").document(event.getId());
+
+        // First, delete the Firestore document
+        eventRef.delete()
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(this, "Event deleted successfully.", Toast.LENGTH_SHORT).show();
+
+                    // Optionally, delete the poster image from Firebase Storage
+                    if (!TextUtils.isEmpty(event.getPosterImageUrl())) {
+                        // Assuming the posterImageUrl contains the storage path
+                        // Adjust this logic based on how you store images
+                        String storagePath = event.getPosterImageUrl(); // Modify as needed
+                        FirebaseStorage.getInstance().getReference(storagePath).delete()
+                                .addOnSuccessListener(aVoid1 -> {
+                                    Log.d(TAG, "Poster image deleted successfully.");
+                                })
+                                .addOnFailureListener(e -> {
+                                    Log.e(TAG, "Error deleting poster image: " + e.getMessage(), e);
+                                });
+                    }
+
+                    loadEvents(); // Refresh the event list
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(this, "Error deleting event: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Error deleting event", e);
+                });
+    }
+}

--- a/app/src/main/res/layout/activity_manage_events.xml
+++ b/app/src/main/res/layout/activity_manage_events.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Toolbar -->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_manage_events"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="Manage Events"
+        android:titleTextColor="@android:color/white"/>
+
+    <!-- RecyclerView for Events -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/eventsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:clipToPadding="false" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/manage_event_item.xml
+++ b/app/src/main/res/layout/manage_event_item.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    card_view:cardCornerRadius="8dp"
+    card_view:cardElevation="4dp"
+    android:layout_marginBottom="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!-- Event Name -->
+        <TextView
+            android:id="@+id/eventNameTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Event Name"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:textColor="@android:color/black" />
+
+        <!-- Event Location -->
+        <TextView
+            android:id="@+id/eventLocationTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Location: XYZ"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="@android:color/darker_gray"
+            android:layout_marginTop="4dp" />
+
+        <!-- Event Poster Image -->
+        <ImageView
+            android:id="@+id/eventPosterImageView"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop"
+            android:layout_marginTop="8dp"
+            android:src="@drawable/ic_placeholder_image" />
+
+        <!-- Action Buttons -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end"
+            android:layout_marginTop="8dp">
+
+            <Button
+                android:id="@+id/deleteQrButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Delete QR Code"
+                android:backgroundTint="@color/design_default_color_error"
+                android:textColor="@android:color/white"
+                android:layout_marginEnd="8dp" />
+
+            <Button
+                android:id="@+id/deleteEventButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Delete Event"
+                android:backgroundTint="@color/design_default_color_error"
+                android:textColor="@android:color/white" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -44,6 +44,14 @@
         android:visible="false"
         android:title="Manage Users"
         android:icon="@drawable/ic_profile_placeholder" />
+
+    <item
+        android:id="@+id/nav_manage_events"
+        android:icon="@android:drawable/ic_menu_gallery"
+        android:title="Manage Events"
+        android:visible="false" />
+
+
 </menu>
 
 <!-- todo: change color of manage media icon to black -->


### PR DESCRIPTION
Kinda title
- Only the admin button for the manage events shows up on the first page
- There is a new event page to allow admins to delete events or QR hash data
- process to remove and generate QR code should be smoother for organizers