### PR TITLE
disabled changing some items when editing event

### DIFF
--- a/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
+++ b/app/src/main/java/com/example/potato1_events/CreateEditEventActivity.java
@@ -762,6 +762,12 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                         if (registrationEnd != null) {
                             registrationEndDateTime.setTime(registrationEnd);
                             waitingListDeadlineButton.setText("Deadline: " + formatDateTime(registrationEndDateTime));
+                            // Check if registration deadline has passed
+                            Date currentDate = new Date();
+                            if (currentDate.after(registrationEndDateTime.getTime())) {
+                                waitingListDeadlineButton.setEnabled(false);
+                                waitingListDeadlineButton.setText("Deadline Passed");
+                            }
                         }
 
                         // Load poster image if available
@@ -789,6 +795,11 @@ public class CreateEditEventActivity extends AppCompatActivity implements Naviga
                         } else {
                             // Waiting list has a capacity
                             waitingListSpotsEditText.setEnabled(true);
+                        }
+
+                        // Disable geolocation checkbox when editing an event
+                        if (isEditingExistingEvent()) {
+                            geolocationCheckBox.setEnabled(false);
                         }
 
                         // Ensure the generateQRCodeButton is visible in edit mode


### PR DESCRIPTION
You can only enable/disable geolocation while creating an event, this setting can't be changed after an event has been created

if reg deadline has passed cant change reg deadline